### PR TITLE
Fix Typo in RollupExecutor Comment

### DIFF
--- a/server/src/rollup_executor.rs
+++ b/server/src/rollup_executor.rs
@@ -536,7 +536,7 @@ impl RollupExecutor {
         // Re-execute all sequenced_unsettled transactions
         for (blob_tx, tx_ctx) in self.unsettled_sequenced_txs.clone() {
             // A reexecution cannot actually fail. Only hyle_output.success can be false
-            // What matters is the optimistic commitments comparaison
+            // What matters is the optimistic commitments comparison
             let _ =
                 Self::execute_blob_tx(&mut self.optimistic_states, &blob_tx, Some(tx_ctx.clone()));
         }


### PR DESCRIPTION


**Description:**  
This pull request corrects a minor typo in a comment within the `rollup_executor.rs` file, changing "comparaison" to "comparison" for improved clarity and code documentation quality.

